### PR TITLE
Change the order of parameters in `contact*cpp` executables

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ For most cases, the following setup is enough:
     # Use ppretty_clusters.py to output meaningful names instead of model indexes
     python ppretty_clusters.py clusters_0.75.out pdb.list
 
+
+**IMPORTANT** In `python3` branch the order of parameters in the contact executables has changed, this might break some of your scripts
+
+```
+before:
+contact_fcc <pdb> <cutoff>
+
+now:
+contact_fcc <cutoff> <pdb>
+```
+
+* * * 
 Authors
 ------
 
@@ -88,4 +100,4 @@ Panagiotis Kastritis
 [Alexandre Bonvin] [2]
 
 [1]: http://www.ncbi.nlm.nih.gov/pubmed/22489062 "FCC @ Pubmed"
-[2]: http://nmr.chem.uu.nl/~abonvin "Alexandre Bonvin's Homepage"
+[2]: http://bonvinlab.org "Alexandre Bonvin's Homepage"

--- a/scripts/make_contacts.py
+++ b/scripts/make_contacts.py
@@ -32,7 +32,7 @@ def _calculate_contacts(contact_exec, pdbfile, d_cutoff, filter_sele=None, exten
 
     pdbname = os.path.basename(pdbfile)[:-4]
 
-    proc = Popen([contact_exec, pdbfile, d_cutoff], stdout=PIPE)
+    proc = Popen([contact_exec, d_cutoff, pdbfile], stdout=PIPE)
     p_output = proc.communicate()[0].decode('utf-8')
     contacts = sorted(list(set([line for line in p_output.split('\n')][:-1])))
 

--- a/src/contact_fcc.cpp
+++ b/src/contact_fcc.cpp
@@ -37,16 +37,16 @@ int main(int argc, char *argv[]) {
 
   if (argc < 3) {
     fprintf(stderr,"ERROR: Too few arguments\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 
-  char *filename = argv[1];
-  float cutoff = atof(argv[2]);
+  float cutoff = atof(argv[1]);
+  char *filename = argv[2];
 
   if (cutoff < 0 || cutoff > 100) {
     fprintf(stderr,"ERROR: Cutoff out of range\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 

--- a/src/contact_fcc_intra.cpp
+++ b/src/contact_fcc_intra.cpp
@@ -31,16 +31,16 @@ int main(int argc, char *argv[]) {
 
   if (argc < 3) {
     fprintf(stderr,"ERROR: Too few arguments\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 
-  char *filename = argv[1];
-  float cutoff = atof(argv[2]);
+  float cutoff = atof(argv[1]);
+  char *filename = argv[2];
 
   if (cutoff < 0 || cutoff > 100) {
     fprintf(stderr,"ERROR: Cutoff out of range\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 

--- a/src/contact_fcc_lig.cpp
+++ b/src/contact_fcc_lig.cpp
@@ -37,16 +37,16 @@ int main(int argc, char *argv[]) {
 
   if (argc < 3) {
     fprintf(stderr,"ERROR: Too few arguments\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 
-  char *filename = argv[1];
-  float cutoff = atof(argv[2]);
+  float cutoff = atof(argv[1]);
+  char *filename = argv[2];
 
   if (cutoff < 0 || cutoff > 100) {
     fprintf(stderr,"ERROR: Cutoff out of range\n");
-    fprintf(stderr, "Usage: contact <pdb file> <cutoff>\n");
+    fprintf(stderr, "Usage: contact <cutoff> <pdb file>\n");
     return 1;
   }
 


### PR DESCRIPTION
In this PR I changed the order of the args in the `contact*cpp` executables, the motivation for this is solely to make it easier to integrate it into https://github.com/haddocking/haddock3/pull/67.

Since this will break the scripts, I also added a note in the readme.md.